### PR TITLE
:bug: Fix deprecated-image-check

### DIFF
--- a/.tekton/cluster-api-provider-aws-mce-210-pull-request.yaml
+++ b/.tekton/cluster-api-provider-aws-mce-210-pull-request.yaml
@@ -334,7 +334,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:1d07d16810c26713f3d875083924d93697900147364360587ccb5a63f2c31012
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/cluster-api-provider-aws-mce-210-push.yaml
+++ b/.tekton/cluster-api-provider-aws-mce-210-push.yaml
@@ -334,7 +334,7 @@ spec:
         - name: name
           value: deprecated-image-check
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:1d07d16810c26713f3d875083924d93697900147364360587ccb5a63f2c31012
+          value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

This PR fixes pipeline rune violations:
```
✕ [Violation] tasks.required_untrusted_task_found
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-210@sha256:dfa6ece0d3c74305bbaba741cc9f9b96a4a46ef0aa12bf85e200b5ceffa104b4
  Reason: Required task "deprecated-image-check" is required and present but not from a trusted task
  Term: deprecated-image-check
  Title: All required tasks are from trusted tasks
  Description: Ensure that the all required tasks are resolved from trusted tasks. To exclude this rule add
  "tasks.required_untrusted_task_found:deprecated-image-check" to the `exclude` section of the policy configuration.
  Solution: Make sure all required tasks in the build pipeline are resolved from trusted tasks.

✕ [Violation] trusted_task.trusted
  ImageRef: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-210@sha256:dfa6ece0d3c74305bbaba741cc9f9b96a4a46ef0aa12bf85e200b5ceffa104b4
  Reason: Untrusted version of PipelineTask "deprecated-base-image-check" (Task "deprecated-image-check") was included in build
  chain comprised of: deprecated-base-image-check. Please upgrade the task version to:
  sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
  Term: deprecated-image-check
  Title: Tasks are trusted
  Description: Check the trust of the Tekton Tasks used in the build Pipeline. There are two modes in which trust is verified. The
  first mode is used if Trusted Artifacts are enabled. In this case, a chain of trust is established for all the Tasks involved in
  creating an artifact. If the chain contains an untrusted Task, then a violation is emitted. The second mode is used as a
  fallback when Trusted Artifacts are not enabled. In this case, **all** Tasks in the build Pipeline must be trusted. To exclude
  this rule add "trusted_task.trusted:deprecated-image-check" to the `exclude` section of the policy configuration.
  Solution: If using Trusted Artifacts, be sure every Task in the build Pipeline responsible for producing a Trusted Artifact is
  trusted. Otherwise, ensure **all** Tasks in the build Pipeline are trusted. Note that trust is eventually revoked from Tasks
  when newer versions are made available.

```

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
