### PR TITLE
✨ add automated sync upstream workflow

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -1,0 +1,223 @@
+---
+name: Sync from Upstream
+
+on:
+  # Run every Monday at 9 AM UTC
+  schedule:
+    - cron: '0 9 * * 1'
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Specific branch to sync (leave empty for all)'
+        required: false
+        type: choice
+        options:
+          - ''
+          - main
+          - backplane-2.10
+          - backplane-2.11
+          - backplane-2.17
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync-upstream:
+    runs-on: ubuntu-latest
+    strategy:
+      # Don't cancel other syncs if one fails
+      fail-fast: false
+      matrix:
+        include:
+          # Downstream branch -> Upstream version mapping
+          # main syncs with latest upstream major release version
+          - downstream_branch: main
+            upstream_version: latest
+          - downstream_branch: backplane-2.10
+            upstream_version: v2.9
+          - downstream_branch: backplane-2.11
+            upstream_version: v2.10
+          - downstream_branch: backplane-2.17
+            upstream_version: v2.11
+
+    steps:
+      - name: Check if branch should be synced
+        id: should_sync
+        run: |
+          if [ -n "${{ github.event.inputs.branch }}" ]; then
+            if [ "${{ github.event.inputs.branch }}" = "${{ matrix.downstream_branch }}" ]; then
+              echo "sync=true" >> $GITHUB_OUTPUT
+            else
+              echo "sync=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "sync=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout downstream repository
+        if: steps.should_sync.outputs.sync == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ matrix.downstream_branch }}
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add upstream remote
+        if: steps.should_sync.outputs.sync == 'true'
+        run: |
+          git remote add upstream https://github.com/kubernetes-sigs/cluster-api-provider-aws.git || true
+          git fetch upstream --tags
+
+      - name: Configure git
+        if: steps.should_sync.outputs.sync == 'true'
+        run: |
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+
+      - name: Find latest upstream release tag
+        if: steps.should_sync.outputs.sync == 'true'
+        id: find_tag
+        run: |
+          # Set pattern based on upstream version
+          if [ "${{ matrix.upstream_version }}" = "latest" ]; then
+            PATTERN="v*.*.*"
+          else
+            PATTERN="${{ matrix.upstream_version }}.*"
+          fi
+
+          # Find the latest tag matching the pattern
+          LATEST_TAG=$(git tag -l "${PATTERN}" --sort=-v:refname | head -n 1)
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No release tag found for pattern: ${PATTERN}"
+            echo "tag_found=false" >> $GITHUB_OUTPUT
+          else
+            echo "Found latest tag: $LATEST_TAG"
+            echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+            echo "tag_found=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check for updates
+        if: steps.should_sync.outputs.sync == 'true' && steps.find_tag.outputs.tag_found == 'true'
+        id: check_updates
+        run: |
+          UPSTREAM_TAG="${{ steps.find_tag.outputs.latest_tag }}"
+
+          # Check if we already have this tag merged
+          if git merge-base --is-ancestor "${UPSTREAM_TAG}" HEAD; then
+            echo "Already up to date with ${UPSTREAM_TAG}"
+            echo "needs_update=false" >> $GITHUB_OUTPUT
+          else
+            echo "Updates available from ${UPSTREAM_TAG}"
+            echo "needs_update=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Create sync branch
+        if: steps.should_sync.outputs.sync == 'true' && steps.find_tag.outputs.tag_found == 'true' && steps.check_updates.outputs.needs_update == 'true'
+        id: create_branch
+        run: |
+          SYNC_BRANCH="sync-upstream-${{ matrix.upstream_version }}-$(date +%Y%m%d-%H%M%S)"
+          git checkout -b "${SYNC_BRANCH}"
+          echo "sync_branch=${SYNC_BRANCH}" >> $GITHUB_OUTPUT
+
+      - name: Merge upstream changes
+        if: steps.should_sync.outputs.sync == 'true' && steps.find_tag.outputs.tag_found == 'true' && steps.check_updates.outputs.needs_update == 'true'
+        id: merge
+        run: |
+          UPSTREAM_TAG="${{ steps.find_tag.outputs.latest_tag }}"
+
+          # Attempt to merge
+          if git merge "${UPSTREAM_TAG}" --no-edit -m "Merge upstream ${UPSTREAM_TAG} into ${{ matrix.downstream_branch }}"; then
+            echo "merge_status=success" >> $GITHUB_OUTPUT
+          else
+            echo "merge_status=conflict" >> $GITHUB_OUTPUT
+            # Abort the merge
+            git merge --abort
+          fi
+
+      - name: Push sync branch
+        if: steps.should_sync.outputs.sync == 'true' && steps.find_tag.outputs.tag_found == 'true' && steps.check_updates.outputs.needs_update == 'true'
+        run: |
+          git push origin "${{ steps.create_branch.outputs.sync_branch }}"
+
+      - name: Create Pull Request
+        if: steps.should_sync.outputs.sync == 'true' && steps.find_tag.outputs.tag_found == 'true' && steps.check_updates.outputs.needs_update == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          UPSTREAM_TAG="${{ steps.find_tag.outputs.latest_tag }}"
+
+          if [ "${{ steps.merge.outputs.merge_status }}" = "success" ]; then
+            PR_TITLE="[Automated] Sync ${{ matrix.downstream_branch }} with upstream ${UPSTREAM_TAG}"
+            PR_BODY="$(cat <<EOF
+          ## Automated Upstream Sync
+
+          This PR syncs the \`${{ matrix.downstream_branch }}\` branch with upstream release \`${UPSTREAM_TAG}\`.
+
+          ### Mapping
+          - Downstream: \`${{ matrix.downstream_branch }}\`
+          - Upstream: \`${{ matrix.upstream_version }}.x\`
+          - Latest tag: \`${UPSTREAM_TAG}\`
+
+          ### Status
+          ✅ Merged cleanly without conflicts
+
+          ### Next Steps
+          - Review the changes
+          - Run any necessary tests
+          - Merge if everything looks good
+
+          🤖 Generated by automated upstream sync workflow
+          EOF
+          )"
+          else
+            PR_TITLE="[Automated] Sync ${{ matrix.downstream_branch }} with upstream ${UPSTREAM_TAG} ⚠️ CONFLICTS"
+            PR_BODY="$(cat <<EOF
+          ## Automated Upstream Sync
+
+          This PR attempts to sync the \`${{ matrix.downstream_branch }}\` branch with upstream release \`${UPSTREAM_TAG}\`.
+
+          ### Mapping
+          - Downstream: \`${{ matrix.downstream_branch }}\`
+          - Upstream: \`${{ matrix.upstream_version }}.x\`
+          - Latest tag: \`${UPSTREAM_TAG}\`
+
+          ### Status
+          ⚠️ **MERGE CONFLICTS DETECTED**
+
+          The automated merge encountered conflicts that need to be resolved manually.
+
+          ### Next Steps
+          1. Check out this branch locally
+          2. Merge upstream/${UPSTREAM_TAG} and resolve conflicts
+          3. Push the resolved changes
+          4. Merge this PR
+
+          🤖 Generated by automated upstream sync workflow
+          EOF
+          )"
+          fi
+
+          gh pr create \
+            --title "${PR_TITLE}" \
+            --body "${PR_BODY}" \
+            --base "${{ matrix.downstream_branch }}" \
+            --head "${{ steps.create_branch.outputs.sync_branch }}" \
+            --label "automated-sync"
+
+      - name: Summary
+        if: steps.should_sync.outputs.sync == 'true'
+        run: |
+          echo "### Sync Summary for ${{ matrix.downstream_branch }}" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${{ steps.find_tag.outputs.tag_found }}" = "false" ]; then
+            echo "⚠️ No upstream release found for ${{ matrix.upstream_version }}" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.check_updates.outputs.needs_update }}" = "false" ]; then
+            echo "✅ Already up to date with ${{ steps.find_tag.outputs.latest_tag }}" >> $GITHUB_STEP_SUMMARY
+          elif [ "${{ steps.merge.outputs.merge_status }}" = "success" ]; then
+            echo "✅ Successfully merged ${{ steps.find_tag.outputs.latest_tag }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⚠️ Merge conflicts with ${{ steps.find_tag.outputs.latest_tag }}" >> $GITHUB_STEP_SUMMARY
+          fi


### PR DESCRIPTION
**What type of PR is this?**

  /kind feature

  **What this PR does / why we need it**:

  This PR adds an automated workflow to sync downstream branches with upstream Kubernetes SIGS releases on a weekly basis.

  The workflow:
  - Runs every Monday at 9 AM UTC (configurable via manual trigger)
  - Syncs multiple downstream branches with their corresponding upstream versions:
    - `main` → upstream latest `release` tag
    - `backplane-2.10` → upstream `v2.9.x` (latest tag)
    - `backplane-2.11` → upstream `v2.10.x` (latest tag)
    - `backplane-2.17` → upstream `v2.11.x` (latest tag)
  - Creates PRs for review (does not push directly to protected branches)
  - Handles merge conflicts gracefully by marking PRs with warnings

  **Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
  N/A

  **Special notes for your reviewer**:

  - Confirm the mappings between downstream and upstream
  - PR has been AI-assisted
  - Only creates PRs, never pushes directly to branches
  - Can be manually triggered to test specific branches
  - Has been tested locally with `act` (apart from the PR creation)

  To test manually after merge:
  1. Go to Actions → "Sync from Upstream" → "Run workflow"
  2. Select a specific branch or leave empty to sync all
  3. Review the created PR before merging

  **Checklist**:

  - [ ] squashed commits
  - [ ] includes documentation
  - [x] includes emoji in title
  - [ ] adds unit tests
  - [ ] adds or updates e2e tests

  **Release note**:
  ```release-note
  None
```