### PR TITLE
🌱 add repo param to upstream-syng github wf

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -201,6 +201,7 @@ jobs:
           fi
 
           gh pr create \
+            --repo "${{ github.repository }}" \
             --title "${PR_TITLE}" \
             --body "${PR_BODY}" \
             --base "${{ matrix.downstream_branch }}" \


### PR DESCRIPTION
**What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:

  Fixes the automated sync-upstream workflow by explicitly specifying the repository in `gh pr create` command. This should resolve the "label not found" error that occurs because `gh` was likely trying to create PRs
  in the upstream repository instead of the fork.

  **Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
N/A

  **Special notes for your reviewer**:
  **Checklist**:

  - [ ] squashed commits
  - [ ] includes documentation
  - [ ] adds emoji in title
  - [ ] adds unit tests
  - [ ] adds or updates e2e tests

  **Release note**:

  ```release-note
  NONE