### PR TITLE
🐛 [sync-upstream] skip .github/workflows files

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -139,9 +139,9 @@ jobs:
             git commit -m "Merge upstream ${UPSTREAM_TAG} into ${{ matrix.downstream_branch }} (with conflicts)"
           fi
 
-          # Keep downstream OWNERS files
-          git checkout ${{ matrix.downstream_branch }} -- OWNERS OWNERS_ALIASES 2>/dev/null || true
-          git diff --quiet HEAD -- OWNERS OWNERS_ALIASES || (git add OWNERS OWNERS_ALIASES && git commit --amend --no-edit)
+          # Keep downstream OWNERS and workflow files
+          git checkout ${{ matrix.downstream_branch }} -- OWNERS OWNERS_ALIASES .github/workflows/ 2>/dev/null || true
+          git diff --quiet HEAD -- OWNERS OWNERS_ALIASES .github/workflows/ || (git add OWNERS OWNERS_ALIASES .github/workflows/ && git commit --amend --no-edit)
 
       - name: Push sync branch
         if: steps.should_sync.outputs.sync == 'true' && steps.find_tag.outputs.tag_found == 'true' && steps.check_updates.outputs.needs_update == 'true'


### PR DESCRIPTION
**What type of PR is this?**

  /kind bug

  **What this PR does / why we need it**:

  Excludes `.github/workflows/` files from upstream sync to maintain downstream-specific workflow configurations.

  **Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
N/A

  **Special notes for your reviewer**:

  N/A

  **Checklist**:

  - [ ] squashed commits
  - [ ] includes documentation
  - [x] includes emoji in title
  - [ ] adds unit tests
  - [ ] adds or updates e2e tests

  **Release note**:

  ```release-note
  NONE