### PR TITLE
Add FIPS build flags and upgrade builder to UBI9

### DIFF
--- a/stolostron/Dockerfile.stolostron
+++ b/stolostron/Dockerfile.stolostron
@@ -1,5 +1,5 @@
 
-FROM registry.access.redhat.com/ubi8/go-toolset:1.24.6-1764274816 AS toolchain
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24 AS toolchain
 
 
 # Run this with docker build --build_arg $(go env GOPROXY) to override the goproxy
@@ -24,7 +24,7 @@ ARG package=.
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.local/share/golang \
-    CGO_ENABLED=0 GOOS=linux GOARCH=${ARCH} go build -ldflags "-extldflags '-static'"  -o manager ${package}
+    CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime GOOS=linux GOARCH=${ARCH} go build -o manager ${package}
 
 # Copy the controller-manager into a thin image
 


### PR DESCRIPTION
## Summary
- Upgrade builder from `ubi8/go-toolset:1.24` to `ubi9/go-toolset:1.24` for FIPS-compatible OpenSSL 3.x
- Change `CGO_ENABLED=0` to `CGO_ENABLED=1` and add `GOEXPERIMENT=strictfipsruntime` for FIPS compliance
- Remove `-extldflags '-static'` (incompatible with CGO-based FIPS)

JIRA: HYPBLD-844

Made with [Cursor](https://cursor.com)