### PR TITLE
🌱 Bump Go version to 1.25.0 for Konflux builder compatibility

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -2,7 +2,7 @@ version: "2"
 
 run:
   timeout: 10m
-  go: "1.24"
+  go: "1.25"
   allow-parallel-runners: true
 
 linters:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ include $(ROOT_DIR_RELATIVE)/common.mk
 # https://suva.sh/posts/well-documented-makefiles
 
 # Go
-GO_VERSION ?=1.24.7
+GO_VERSION ?=1.25.0
 GO_DIRECTIVE_VERSION ?= 1.24.0
 GO_CONTAINER_IMAGE ?= golang:$(GO_VERSION)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/cluster-api-provider-aws/v2
 
-go 1.24.0
+go 1.25.0
 
 // Required to include https://github.com/kubernetes-sigs/cluster-api/pull/13022
 replace sigs.k8s.io/cluster-api/test => sigs.k8s.io/cluster-api/test v1.11.4-0.20251125201037-d322ff6baa2f


### PR DESCRIPTION
## Summary

- Bumps `go` directive in `go.mod` from `1.24.0` to `1.25.0`
- The ART/Konflux builder image uses Go 1.25.x (`ubi9/go-toolset:1.25.9`), but `go.mod` specifies `go 1.24.0`, causing `go build` to fail during the container image build
- Part of ACM-ART migration efforts

## Test plan

- [ ] Verify Konflux build passes (build-images task succeeds)