### PR TITLE
🌱 chore: bump golangci-lint to v2.12.2

### DIFF
--- a/.github/workflows/pr-golangci-lint.yaml
+++ b/.github/workflows/pr-golangci-lint.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # tag=v9.2.1
         with:
-          version: v2.7.0
+          version: v2.12.2
           working-directory: ${{matrix.working-directory}}
       - name: Lint API
         run: make lint-api


### PR DESCRIPTION
## Summary
- Bumps golangci-lint from v2.7.0 to v2.12.2 in the downstream lint workflow to match upstream `release-2.13`
- Fixes `nolintlint` false positives on synced code (unused `//nolint:gosec` directives that are valid in the upstream lint version but flagged by the older downstream version)

## Test plan
- [ ] Lint CI passes on this PR
- [ ] Re-run lint on the sync PR (#129) after merging this