### PR TITLE
🌱 chore: update Konflux pipelines to target backplane-5.1

### DIFF
--- a/.tekton/cluster-api-provider-aws-mce-51-pull-request.yaml
+++ b/.tekton/cluster-api-provider-aws-mce-51-pull-request.yaml
@@ -4,17 +4,18 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-api-provider-aws?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "backplane-5.0"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
+      == "backplane-5.1"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-50
-    appstudio.openshift.io/component: cluster-api-provider-aws-mce-50
+    appstudio.openshift.io/application: release-mce-51
+    appstudio.openshift.io/component: cluster-api-provider-aws-mce-51
     pipelines.appstudio.openshift.io/type: build
-  name: cluster-api-provider-aws-mce-50-on-push
+  name: cluster-api-provider-aws-mce-51-on-pull-request
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -23,13 +24,12 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-50:{{revision}}
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-51:on-pr-{{revision}}
+  - name: image-expires-after
+    value: 5d
   - name: build-platforms
     value:
     - linux/x86_64
-    - linux/arm64
-    - linux/ppc64le
-    - linux/s390x
   - name: dockerfile
     value: stolostron/Dockerfile.stolostron
   - name: path-context
@@ -40,12 +40,6 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}]'
-  - name: send-slack-notification
-    value: true
-  - name: konflux-application-name
-    value: release-mce-50
-  - name: slack-member-id
-    value: C07JR0ARW1E # capi-squad channel-id.
   pipelineRef:
     resolver: git
     params:
@@ -56,7 +50,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cluster-api-provider-aws-mce-50
+    serviceAccountName: build-pipeline-cluster-api-provider-aws-mce-51
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/cluster-api-provider-aws-mce-51-push.yaml
+++ b/.tekton/cluster-api-provider-aws-mce-51-push.yaml
@@ -4,18 +4,17 @@ metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/stolostron/cluster-api-provider-aws?rev={{revision}}
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
-    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
-    pipelinesascode.tekton.dev/cancel-in-progress: "true"
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "backplane-5.0"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
+      == "backplane-5.1"
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: release-mce-50
-    appstudio.openshift.io/component: cluster-api-provider-aws-mce-50
+    appstudio.openshift.io/application: release-mce-51
+    appstudio.openshift.io/component: cluster-api-provider-aws-mce-51
     pipelines.appstudio.openshift.io/type: build
-  name: cluster-api-provider-aws-mce-50-on-pull-request
+  name: cluster-api-provider-aws-mce-51-on-push
   namespace: crt-redhat-acm-tenant
 spec:
   params:
@@ -24,12 +23,13 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-50:on-pr-{{revision}}
-  - name: image-expires-after
-    value: 5d
+    value: quay.io/redhat-user-workloads/crt-redhat-acm-tenant/cluster-api-provider-aws-mce-51:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
+    - linux/arm64
+    - linux/ppc64le
+    - linux/s390x
   - name: dockerfile
     value: stolostron/Dockerfile.stolostron
   - name: path-context
@@ -40,6 +40,12 @@ spec:
     value: "true"
   - name: prefetch-input
     value: '[{"type": "gomod", "path": "."}]'
+  - name: send-slack-notification
+    value: true
+  - name: konflux-application-name
+    value: release-mce-51
+  - name: slack-member-id
+    value: C07JR0ARW1E # capi-squad channel-id.
   pipelineRef:
     resolver: git
     params:
@@ -50,7 +56,7 @@ spec:
       - name: pathInRepo
         value: pipelines/common.yaml
   taskRunTemplate:
-    serviceAccountName: build-pipeline-cluster-api-provider-aws-mce-50
+    serviceAccountName: build-pipeline-cluster-api-provider-aws-mce-51
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
**What type of PR is this?**

  /kind cleanup

  **What this PR does / why we need it**:

Renames the Konflux Tekton pipelines from `mce-50` to `mce-51` to target the `backplane-5.1` branch. This follows the same pattern used in #91 for the 5.0 release preparation, the main branch carries only the pipeline files for the current release target.

  Supersedes #92.

  **Which issue(s) this PR fixes** _(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)_:
  Fixes #

  **Special notes for your reviewer**:

  This is a rename (not an addition) of the Tekton files, matching the approach from #91. The `backplane-5.0` branch already has its own copy of the `mce-50` pipeline files.

  **AI Usage**:

None

  **Checklist**:

  - [x] squashed commits
  - [ ] includes documentation
  - [ ] includes AI generated content
  - [x] includes emoji in title
  - [ ] adds unit tests
  - [ ] adds or updates e2e tests

  **Release note**:

  ```release-note
  NONE