### PR TITLE
🌱 chore: update backplane-5.0 to sync with upstream release-2.13

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -38,7 +38,7 @@ jobs:
           - downstream_branch: main
             upstream_branch: release-2.13
           - downstream_branch: backplane-5.0
-            upstream_branch: release-2.12
+            upstream_branch: release-2.13
           - downstream_branch: backplane-2.10
             upstream_branch: release-2.9
           - downstream_branch: backplane-2.11


### PR DESCRIPTION
**What type of PR is this?**

  /kind cleanup

  **What this PR does / why we need it**:

Updates the sync-upstream workflow so `backplane-5.0` tracks upstream `release-2.13` instead of `release-2.12`.

  **Which issue(s) this PR fixes**:
  Fixes #

  **Special notes for your reviewer**:

Backplane-5.0 is not yet available hence we can skip upstream release `2.12` and go directly with `2.13`

  No downstream branch will track upstream `release-2.12`.

  **AI Usage**:

None

  **Checklist**:

  - [x] squashed commits
  - [ ] includes documentation
  - [ ] includes AI generated content
  - [x] includes emoji in title
  - [ ] adds unit tests
  - [ ] adds or updates e2e tests

  **Release note**:

  ```release-note
  NONE